### PR TITLE
Updated the readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Installation
 ::
 
 	bro-pkg refresh
-	bro-pkg install bro/sethhall/top-dns
+	bro-pkg install bro/corelight/top-dns
 
 Configuration
 -------------


### PR DESCRIPTION
Hi,

Possibly a bit picky but I updated the README.rst to point the installation from 'bro-pkg install bro/sethhall/top-dns' to 'bro-pkg install bro/corelight/top-dns'

Cheers, Mike

