### PR TITLE
zeek_init needed for Zeek 3.2.0

### DIFF
--- a/scripts/main.bro
+++ b/scripts/main.bro
@@ -47,7 +47,11 @@ export {
 	};
 }
 
+@ifdef ( zeek_init )
+event zeek_init() &priority=5
+@else
 event bro_init() &priority=5
+@endif
 	{
 	Log::create_stream(TopDNS::LOG, [$columns=Info, $path="top_dns"]);
 


### PR DESCRIPTION
Attempting to use the top-dns package in Zeek 3.2.0 results in the following error:

```
error in /opt/zeek/share/zeek/site/packages/./top-dns/./main.bro, line 51: event bro_init() is no longer available, use zeek_init() instead                                                                                                   
```

This PR will still allow backwards compatibility with previous versions for the time being.